### PR TITLE
Add the link to the method of setting up docker for windows and WSL

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -70,7 +70,8 @@ You see there are files under `YAMP` directory.
 Run docker daemon
 
 * Mac: Run "Applications > Docker > Docker Quickstart Terminal".
-* Windows: I am not sure.
+* Windows: Run "Windows key > Docker Desktope".
+* Windows (WSL): [Here] (https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly).
 * Linux(Ubuntu): `$ sudo systemctl start docker` or `$ sudo service docker start`
 
 Run QEMU container to run arm64 container on it on the opened terminal. This operation is only for first time.

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ Run docker daemon
 
 * Mac: Run "Applications > Docker > Docker Quickstart Terminal".
 * Windows: Run "Windows key > Docker Desktope".
-* Windows (WSL): [Here] (https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly).
+* Windows (WSL): [Here](https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly).
 * Linux(Ubuntu): `$ sudo systemctl start docker` or `$ sudo service docker start`
 
 Run QEMU container to run arm64 container on it on the opened terminal. This operation is only for first time.


### PR DESCRIPTION
I tried to run docker in windows subsystem Linux, how ever setting up docker for WSL is not straight forward. After several attempts, I found one method that helped me to run docker daemon successfully in WSL. The link to the method is added to the development.md.