### PR TITLE
Share an entire top directory with /home/gogut in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ login-root :
 .PHONY : login-root
 
 login :
-	docker run -it -u gogut -w /home/gogut -v "$(CWD)/work:/home/gogut/work" "$(TAG)-dev"
+	docker run -it -u gogut -w /home/gogut -v "$(CWD):/home/gogut" "$(TAG)-dev"
 .PHONY : login
 
 clean :


### PR DESCRIPTION
when doing "make login".
Remove volume mounted work directory.
